### PR TITLE
fixed ProfitTable so that it doesn't have any whitespace

### DIFF
--- a/frontend/src/main/components/Commons/ProfitsTable.js
+++ b/frontend/src/main/components/Commons/ProfitsTable.js
@@ -8,7 +8,7 @@ export default function ProfitsTable({ profits }) {
         [
             {
                 Header: "Profit",
-                accessor: (row) => `$${row.amount.toFixed(2)}`,
+                accessor: (row) => `$${row.amount.toFixed(2)}`
             },
             {
                 Header: "Date",

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -10,7 +10,7 @@ var tableStyle = {
     "maxWidth": "-moz-fit-content",
     "margin": "0 auto",
     "overflowX": "auto",
-    "whiteSpace": "nowrap"
+    "whiteSpace": "nowrap",
 };
 var paginationStyle = {
     "display": "flex",
@@ -42,7 +42,10 @@ export default function OurTable({ columns, data, testid = "testid", ...rest }) 
                     <tr {...headerGroup.getHeaderGroupProps()}>
                         {headerGroup.headers.map(column => (
                             <th
-                                {...column.getHeaderProps(column.getSortByToggleProps())}
+                                {...column.getHeaderProps({
+                                    ...column.getSortByToggleProps(), // Include sorting functionality
+                                    style: { width: column.width || "auto" }, // Apply column width
+                                })}
                                 data-testid={`${testid}-header-${column.id}`}
                             >
                                 {column.render('Header')}
@@ -66,7 +69,9 @@ export default function OurTable({ columns, data, testid = "testid", ...rest }) 
                             {row.cells.map((cell, _index) => {
                                 return (
                                     <td
-                                        {...cell.getCellProps()}
+                                        {...cell.getCellProps({
+                                            style: { width: cell.column.width || "auto" }, // Apply column width
+                                        })}
                                         data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
                                     >
                                         {cell.render('Cell')}


### PR DESCRIPTION
## Overview
Modifies OurTable.js so that tables take up the full container space, leaving 0 whitespace, as in the case of ProfitTable. Users should be able to see clean, neat-looking Profit Tables in their commons.

## Screenshots (Optional)

![image](https://github.com/user-attachments/assets/8c07efde-3d79-47c0-b150-6629e5d7b6ab)

## Feedback Request (Optional)
Please give suggestions on the following:
- I had to modify OurTables.js in order to force the width changes to take place on ProfitTable. OurTables.js is used in the leaderboard table and reports table as well, if there is another way of forcing ProfitTable to change its width without modifying OurTable.js let me know.

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the project.
3. Go to this page.
4. Test this function.

## Tests
<!--Add any additional tests or required tests-->
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #4 
